### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,12 @@ Following the previous example, if I want to check the values of my
     echo $value->commentsNumber;
 ```
 
+There is a shorthand method for changing value of variable instance.
+
+```php
+    Variable::set('CODE-OF-MY-CONFIGURATION-VARIABLE', 115);
+```
+
 ## Further considerations
 
 Remember to bootstrap the Module if you want to extend the VariableController 

--- a/src/models/Variable.php
+++ b/src/models/Variable.php
@@ -206,8 +206,17 @@ class Variable extends ActiveRecord {
             throw new InvalidParamException('Configuration not found');
         }
         $c->value = $value;
-        static::$cached[$config] = $value;
-        return $c->save();
+        if($c->save()) {
+            static::$cached[$config] = $value;
+            return true;
+        } else {
+            $firstError = $c->getFirstError('value');
+            if($firstError) {
+                throw new InvalidParamException($firstError);
+            } else {
+                return false;
+            }
+        }
     }
 
     /**

--- a/src/models/Variable.php
+++ b/src/models/Variable.php
@@ -193,6 +193,24 @@ class Variable extends ActiveRecord {
     }
 
     /**
+     * Sets the value of the configuration variable.
+     *
+     * @param string $config
+     * @param mixed $value
+     * @return bool
+     * @throws InvalidParamException
+     */
+    public static function set($config, $value) {
+        $c = static::findOne(['code' => $config]);
+        if ($c === null) {
+            throw new InvalidParamException('Configuration not found');
+        }
+        $c->value = $value;
+        static::$cached[$config] = $value;
+        return $c->save();
+    }
+
+    /**
      * Returns the allowed variable types.
      * 
      * @return array


### PR DESCRIPTION
I created Variable::set method in order to avoid repeated code for finding, changing attribute and saving. User should only call `Variable::set('VAR-NAME', $varValue);` It will alter value of existing variable. If wrong type of value is passed, exception will be thrown. 
